### PR TITLE
re-init i2c peripherals when soft reset()

### DIFF
--- a/Adafruit_LTR390.cpp
+++ b/Adafruit_LTR390.cpp
@@ -8,7 +8,7 @@
  * 	I2C Driver for the LTR390 I2C UV and Light sensor
  *
  * 	This is a library for the Adafruit LTR390 breakout:
- * 	http://www.adafruit.com/
+ * 	https://www.adafruit.com/product/4831
  *
  * 	Adafruit invests time and resources providing this open source code,
  *  please support Adafruit and open-source hardware by purchasing products from
@@ -85,6 +85,13 @@ bool Adafruit_LTR390::reset(void) {
   // this write will fail because it resets before acking?
   softreset.write(1);
   delay(10);
+
+  // Missing ACK from above soft-reset cause permanent bus issue with
+  // port such as nRF52, RP2040. Re-init I2C peripherals is required for
+  // recovery
+  i2c_dev->end();
+  i2c_dev->begin();
+
   // however it does reset, check that the value is zero
   if (softreset.read()) {
     return false;

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Adafruit_LTR390 [![Build Status](https://github.com/adafruit/Adafruit_LTR390/wor
 
 This is the Adafruit LTR390 UV sensor library
 
-Tested and works great with the [Adafruit LTR390 Breakout Board](http://www.adafruit.com/)
+Tested and works great with the [Adafruit LTR390 Breakout Board](https://www.adafruit.com/product/4831)
 
 [<img src="assets/board.png?raw=true" width="500px">](https://www.adafruit.com/products/4831)
 


### PR DESCRIPTION
LTR390 reset before sending ACK, it cause internal error for nrf52 and rp2040 (less severe). And re-init (end() then begin()) is needed to reset peripheral state. Fix #2, requires
- https://github.com/adafruit/Adafruit_BusIO/pull/68 with a new release for compiling
- https://github.com/adafruit/Adafruit_nRF52_Arduino/pull/703#issuecomment-977995728